### PR TITLE
Fix WebTestClient leak when ParameterizedTypeReference is used

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -506,7 +506,14 @@ class DefaultWebTestClient implements WebTestClient {
 
 		@Override
 		public <T> FluxExchangeResult<T> returnResult(ParameterizedTypeReference<T> elementTypeRef) {
-			Flux<T> body = this.response.bodyToFlux(elementTypeRef);
+			Flux<T> body;
+			if (elementTypeRef.getType().equals(Void.class)) {
+				this.response.releaseBody().block();
+				body = Flux.empty();
+			}
+			else {
+				body = this.response.bodyToFlux(elementTypeRef);
+			}
 			return new FluxExchangeResult<>(this.exchangeResult, body);
 		}
 

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/WebTestClientTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/WebTestClientTests.java
@@ -1,0 +1,32 @@
+package org.springframework.test.web.reactive.server;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WebTestClientTests {
+
+    @Test
+    void returnResultParameterizedTypeReferenceVoid() {
+        ClientResponse clientResponse = mock(ClientResponse.class);
+        when(clientResponse.statusCode()).thenReturn(HttpStatus.OK);
+        when(clientResponse.releaseBody()).thenReturn(Mono.empty());
+
+        WebTestClient.ResponseSpec responseSpec = new DefaultWebTestClient.DefaultResponseSpec(
+                new ExchangeResult(null, null, null, null, null, null, null, null, null, null),
+                clientResponse,
+                null,
+                result -> {},
+                Duration.ofSeconds(5)
+        );
+
+        WebTestClient.FluxExchangeResult<Void> result = responseSpec.returnResult(ParameterizedTypeReference.forType(Void.class));
+        assertThat(result.getResponseBody()).isEmpty();
+    }
+}


### PR DESCRIPTION
Related to #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Mayil-AI-Sandbox/spring-framework_33389/issues/1?shareId=f63f1395-7c1c-4454-ab0b-2cc0ba49988b).